### PR TITLE
If image is loaded from memory, save as a tempfile before uploading

### DIFF
--- a/src/main/java/org/vanvalenlab/ImageJobManager.java
+++ b/src/main/java/org/vanvalenlab/ImageJobManager.java
@@ -2,12 +2,8 @@ package org.vanvalenlab;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.io.FileInfo;
 import ij.plugin.PlugIn;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 public class ImageJobManager extends KioskJobManager implements PlugIn {
@@ -21,22 +17,8 @@ public class ImageJobManager extends KioskJobManager implements PlugIn {
                 return;
             }
 
-            String filePath;
-            FileInfo fileInfo = imp.getOriginalFileInfo();
+            String filePath = ImageJobManager.getFilePath(imp);
 
-            if (null == fileInfo) {
-                Path tmpDir = Files.createTempDirectory("DeepCell_Kiosk");
-                // image is in memory. save file as temporary tiff file.
-
-                filePath = Paths.get(tmpDir.toString(), imp.getTitle()).toString();
-                boolean success = IJ.saveAsTiff(imp, filePath);
-                if (!success) {
-                    IJ.showMessage("Could not save active image as tiff file for upload.");
-                    return;
-                }
-            } else {
-                filePath = String.format("%s%s", fileInfo.directory, fileInfo.fileName);
-            }
             // show options menu (including hostname)
             Map<String, Object> options = this.configureOptions();
             if (null == options) return;

--- a/src/main/java/org/vanvalenlab/ImageJobManager.java
+++ b/src/main/java/org/vanvalenlab/ImageJobManager.java
@@ -5,6 +5,9 @@ import ij.ImagePlus;
 import ij.io.FileInfo;
 import ij.plugin.PlugIn;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 public class ImageJobManager extends KioskJobManager implements PlugIn {
@@ -18,9 +21,22 @@ public class ImageJobManager extends KioskJobManager implements PlugIn {
                 return;
             }
 
+            String filePath;
             FileInfo fileInfo = imp.getOriginalFileInfo();
-            String filePath = String.format("%s%s", fileInfo.directory, fileInfo.fileName);
 
+            if (null == fileInfo) {
+                Path tmpDir = Files.createTempDirectory("DeepCell_Kiosk");
+                // image is in memory. save file as temporary tiff file.
+
+                filePath = Paths.get(tmpDir.toString(), imp.getTitle()).toString();
+                boolean success = IJ.saveAsTiff(imp, filePath);
+                if (!success) {
+                    IJ.showMessage("Could not save active image as tiff file for upload.");
+                    return;
+                }
+            } else {
+                filePath = String.format("%s%s", fileInfo.directory, fileInfo.fileName);
+            }
             // show options menu (including hostname)
             Map<String, Object> options = this.configureOptions();
             if (null == options) return;

--- a/src/main/java/org/vanvalenlab/KioskJobManager.java
+++ b/src/main/java/org/vanvalenlab/KioskJobManager.java
@@ -1,5 +1,6 @@
 package org.vanvalenlab;
 
+import ij.io.FileInfo;
 import org.vanvalenlab.exceptions.KioskJobFailedException;
 
 import ij.IJ;
@@ -8,6 +9,9 @@ import ij.gui.GenericDialog;
 import ij.io.Opener;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -92,6 +96,29 @@ public class KioskJobManager {
         options.put(Constants.EXPIRE_TIME_SECONDS, (int)gd.getNextNumber());
 
         return options;
+    }
+
+    /**
+     * Get the file path of the image. Saves a temporary file if necessary.
+     * @param imp An IJ ImagePlus object that may need to be saved.
+     * @return The full file path of the image, as a String.
+     */
+    public static String getFilePath(ImagePlus imp) throws IOException {
+        String filePath;
+        FileInfo fileInfo = imp.getOriginalFileInfo();
+
+        if (null == fileInfo) {
+            Path tmpDir = Files.createTempDirectory("DeepCell_Kiosk");
+            // image is in memory. save file as temporary tiff file.
+            filePath = Paths.get(tmpDir.toString(), imp.getTitle()).toString();
+            boolean success = IJ.saveAsTiff(imp, filePath);
+            if (!success) {
+                throw new IOException("Could not save active image as tiff file for upload.");
+            }
+        } else {
+            filePath = String.format("%s%s", fileInfo.directory, fileInfo.fileName);
+        }
+        return filePath;
     }
 
     /**

--- a/src/test/java/org/vanvalenlab/KioskJobManagerTest.java
+++ b/src/test/java/org/vanvalenlab/KioskJobManagerTest.java
@@ -1,6 +1,7 @@
 package org.vanvalenlab;
 
 import com.google.gson.Gson;
+import ij.ImagePlus;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -8,6 +9,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.vanvalenlab.exceptions.KioskJobFailedException;
 import org.vanvalenlab.responses.*;
@@ -15,6 +17,7 @@ import org.vanvalenlab.responses.*;
 import java.awt.*;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -46,6 +49,24 @@ public class KioskJobManagerTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testGetFilePath() throws IOException {
+        BufferedImage img = new BufferedImage(20, 20, BufferedImage.TYPE_INT_ARGB);
+        ImagePlus imp = new ImagePlus("test.tiff", img);
+
+        // image is not saved, so it will return a temporary file path.
+        String filePath = KioskJobManager.getFilePath(imp);
+
+        // load a new image from the same file path.
+        ImagePlus newImp = new ImagePlus(filePath);
+
+        String newPath = KioskJobManager.getFilePath(newImp);
+        assert (newPath.equals(filePath));
+    }
 
     @Test
     public void testConfigureOptions() {


### PR DESCRIPTION
QuPath can send images to their own internal ImageJ instance. However, when they are sent, they will not have a current image file path. To process these images, they must first be saved as a temporary file, and then uploaded.