### PR TITLE
Upload JARs to releases using upload-release-asset

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,8 +21,16 @@ jobs:
       - name: Setup headless environment
         run: |
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+      
+      - name: Set the upload asset name
+        run: |
+          NAME="$(mvn -B -q -Dexec.executable=echo -Dexec.args='${project.artifactId}-${project.version}' --non-recursive exec:exec 2>/dev/null)"
+          echo '::set-env name=NAME::$NAME'
 
-      - name: Publish package
-        run: mvn -B deploy
+      - name: Upload to release
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.release.upload_url }}
+          asset_path: ./target/${{ env.NAME }}-${{ github.event.release.tag_name }}.jar

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Java CI
+name: build
 
 on:
   - push

--- a/pom.xml
+++ b/pom.xml
@@ -202,12 +202,4 @@
     <system>None</system>
   </ciManagement>
 
-  <distributionManagement>
-    <repository>
-      <id>github</id>
-      <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/vanvalenlab/kiosk-imagej-plugin</url>
-    </repository>
-  </distributionManagement>
-
 </project>


### PR DESCRIPTION
Use actions/upload-release-asset@v1 to upload the JAR file rather than `mvn deploy`.