### PR TITLE
Retry HTTP requests up to MAX_HTTP_RETRIES times using RetryInterceptor.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Coveralls
         if: env.COVERALLS_REPO_TOKEN != null
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           mvn test jacoco:report coveralls:report -B -D repoToken=${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/src/main/java/org/vanvalenlab/Constants.java
+++ b/src/main/java/org/vanvalenlab/Constants.java
@@ -15,6 +15,9 @@ public final class Constants {
     static final MediaType MEDIA_TYPE_JSON = MediaType.get("application/json; charset=utf-8");
     static final MediaType MEDIA_TYPE_FORM_DATA = MediaType.get("multipart/form-data; charset=utf-8");
 
+    // Retry failed HTTP requests
+    static final int MAX_HTTP_RETRIES = 3;
+
     // GUI prompts / messages
     static final String SELECT_FILE_MESSAGE = "Select the file to submit to the DeepCell Kiosk";
     static final String SELECT_JOB_TITLE = "Select a Job Type";

--- a/src/main/java/org/vanvalenlab/KioskHttpClient.java
+++ b/src/main/java/org/vanvalenlab/KioskHttpClient.java
@@ -67,6 +67,7 @@ public class KioskHttpClient {
         builder.connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(60, TimeUnit.SECONDS)
+            .addInterceptor(new RetryInterceptor())
             .retryOnConnectionFailure(true);
         return builder.build();
     }

--- a/src/main/java/org/vanvalenlab/RetryInterceptor.java
+++ b/src/main/java/org/vanvalenlab/RetryInterceptor.java
@@ -1,0 +1,33 @@
+package org.vanvalenlab;
+
+import okhttp3.*;
+
+import java.io.IOException;
+
+public class RetryInterceptor implements Interceptor {
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request original = chain.request();
+        Request request = original.newBuilder()
+            .method(original.method(), original.body())
+            .build();
+
+        Response response = chain.proceed(request);
+
+        int retryCount = 1;
+
+        while (!response.isSuccessful() && retryCount < Constants.MAX_HTTP_RETRIES) {
+            response.close();
+
+            request = original.newBuilder()
+                .method(original.method(), original.body())
+                .build();
+
+            response = chain.proceed(request);
+            retryCount++;
+        }
+        return response;
+    }
+
+}

--- a/src/test/java/org/vanvalenlab/KioskHttpClientTest.java
+++ b/src/test/java/org/vanvalenlab/KioskHttpClientTest.java
@@ -47,8 +47,8 @@ public class KioskHttpClientTest {
     @Test
     public void testSendHttpRequest() throws IOException {
         Request request = new Request.Builder()
-                .url(baseUrl)
-                .build();
+            .url(baseUrl)
+            .build();
 
         // successful response
         String expectedResponse = "Success!";
@@ -57,9 +57,11 @@ public class KioskHttpClientTest {
         assertEquals(response, expectedResponse);
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskHttpClient.sendHttpRequest(request)
+            kioskHttpClient.sendHttpRequest(request)
         );
     }
 
@@ -81,15 +83,17 @@ public class KioskHttpClientTest {
         assertEquals(null, response);
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskHttpClient.getRedisValue(redisHash, redisKey)
+            kioskHttpClient.getRedisValue(redisHash, redisKey)
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskHttpClient.getRedisValue(redisHash, redisKey)
+            kioskHttpClient.getRedisValue(redisHash, redisKey)
         );
     }
 
@@ -102,7 +106,7 @@ public class KioskHttpClientTest {
         String expectedValue = "uploadedFilePath.jpg";
         String expectedURL = "http://test.com/uploadedFilePath.jpg";
         String expectedResponse = g.toJson(
-                new UploadFileResponse(expectedValue, expectedURL));
+            new UploadFileResponse(expectedValue, expectedURL));
 
         server.enqueue(new MockResponse().setBody(expectedResponse));
         String response = kioskHttpClient.uploadFile(filePath);
@@ -114,22 +118,24 @@ public class KioskHttpClientTest {
         assertEquals(null, response);
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskHttpClient.uploadFile(filePath)
+            kioskHttpClient.uploadFile(filePath)
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskHttpClient.uploadFile(filePath)
+            kioskHttpClient.uploadFile(filePath)
         );
 
         // test local file does not exist.
         String invalidFilePath = String.format(
-                "%s%s", folder.getRoot().getAbsolutePath(), "invalid.jpg");
+            "%s%s", folder.getRoot().getAbsolutePath(), "invalid.jpg");
         assertThrows(IOException.class, () ->
-                kioskHttpClient.uploadFile(invalidFilePath)
+            kioskHttpClient.uploadFile(invalidFilePath)
         );
     }
 
@@ -151,15 +157,17 @@ public class KioskHttpClientTest {
         assertEquals(0, response); // primitive int defaults to 0.
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskHttpClient.expireRedisHash(redisHash, expireTime)
+            kioskHttpClient.expireRedisHash(redisHash, expireTime)
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskHttpClient.expireRedisHash(redisHash, expireTime)
+            kioskHttpClient.expireRedisHash(redisHash, expireTime)
         );
     }
 
@@ -179,15 +187,17 @@ public class KioskHttpClientTest {
         assertArrayEquals(response, null);
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskHttpClient.getJobTypes()
+            kioskHttpClient.getJobTypes()
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskHttpClient.getJobTypes()
+            kioskHttpClient.getJobTypes()
         );
     }
 
@@ -208,15 +218,17 @@ public class KioskHttpClientTest {
         assertEquals(null, response);
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskHttpClient.getStatus(redisHash)
+            kioskHttpClient.getStatus(redisHash)
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskHttpClient.getStatus(redisHash)
+            kioskHttpClient.getStatus(redisHash)
         );
     }
 
@@ -239,15 +251,17 @@ public class KioskHttpClientTest {
         assertEquals(null, response);
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskHttpClient.createJob(imageName, uploadedName, jobType)
+            kioskHttpClient.createJob(imageName, uploadedName, jobType)
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskHttpClient.createJob(imageName, uploadedName, jobType)
+            kioskHttpClient.createJob(imageName, uploadedName, jobType)
         );
     }
 

--- a/src/test/java/org/vanvalenlab/KioskJobManagerTest.java
+++ b/src/test/java/org/vanvalenlab/KioskJobManagerTest.java
@@ -85,28 +85,32 @@ public class KioskJobManagerTest {
         robot.setAutoWaitForIdle(true);
 
         // test successful request
-//        server.enqueue(new MockResponse().setBody(responseStr));
-//        executor.submit(() -> {
-//            System.out.println("First robot delay");
-//            robot.delay(100);
-//            System.out.println("About to push key");
-//            robot.keyPress(InputEvent.BUTTON1_DOWN_MASK);
-//            System.out.println("key has been pressed");
-//        });
-//        jobType = KioskJobManager.selectJobType(baseUrl.toString());
-//        System.out.println("jobType");
-//        assertEquals(expectedJobType, jobType);
+        // server.enqueue(new MockResponse().setBody(responseStr));
+        // executor.submit(() -> {
+        //     System.out.println("First robot delay");
+        //     robot.delay(100);
+        //     System.out.println("About to push key");
+        //     robot.keyPress(InputEvent.BUTTON1_DOWN_MASK);
+        //     System.out.println("key has been pressed");
+        // });
+        // jobType = KioskJobManager.selectJobType(baseUrl.toString());
+        // System.out.println("jobType");
+        // assertEquals(expectedJobType, jobType);
 
         // test failed http request
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("{}"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("{}"));
+        }
         assertThrows(IOException.class, () ->
-                KioskJobManager.selectJobType(baseUrl.toString())
+            KioskJobManager.selectJobType(baseUrl.toString())
         );
 
         // test empty json body
-        server.enqueue(new MockResponse().setBody("{}"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("{}"));
+        }
         assertThrows(IOException.class, () ->
-                KioskJobManager.selectJobType(baseUrl.toString())
+            KioskJobManager.selectJobType(baseUrl.toString())
         );
     }
 
@@ -125,7 +129,7 @@ public class KioskJobManagerTest {
         defaults.put(Constants.EXPIRE_TIME_SECONDS, expireTime);
 
         String uploadResponse = g.toJson(new UploadFileResponse(
-                "uploadedName", "imageURL"));
+            "uploadedName", "imageURL"));
         String createResponse = g.toJson(new CreateJobResponse("hash"));
         String successStatusResponse = g.toJson(new GetStatusResponse(Constants.SUCCESS_STATUS));
         String failStatusResponse = g.toJson(new GetStatusResponse(Constants.FAILED_STATUS));
@@ -161,14 +165,16 @@ public class KioskJobManagerTest {
 
         // fails due to failed status
         assertThrows(KioskJobFailedException.class, () ->
-                KioskJobManager.runJob(jobType, filePath, defaults)
+            KioskJobManager.runJob(jobType, filePath, defaults)
         );
 
         // job hits errors
         // bad HTTP response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("{}"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("{}"));
+        }
         assertThrows(IOException.class, () ->
-                KioskJobManager.runJob(jobType, filePath, defaults)
+            KioskJobManager.runJob(jobType, filePath, defaults)
         );
         // invalid file path.
         String invalidPath = folder.getRoot() + "nofile.jpg";

--- a/src/test/java/org/vanvalenlab/KioskJobTest.java
+++ b/src/test/java/org/vanvalenlab/KioskJobTest.java
@@ -85,11 +85,11 @@ public class KioskJobTest {
         // 4 status updates, null -> testing -> testing -> done
         server.enqueue(new MockResponse().setBody("{}"));
         server.enqueue(new MockResponse().setBody(
-                g.toJson(new GetStatusResponse("testing"))));
+            g.toJson(new GetStatusResponse("testing"))));
         server.enqueue(new MockResponse().setBody(
-                g.toJson(new GetStatusResponse("testing"))));
+            g.toJson(new GetStatusResponse("testing"))));
         server.enqueue(new MockResponse().setBody(
-                g.toJson(new GetStatusResponse(expectedFinalStatus))));
+            g.toJson(new GetStatusResponse(expectedFinalStatus))));
 
         String finalStatus = kioskJob.waitForFinalStatus(updateInterval);
         assertEquals(expectedFinalStatus, finalStatus);
@@ -105,10 +105,10 @@ public class KioskJobTest {
         String expectedURL = "http://test.com/uploadedFilePath.jpg";
 
         String expectedUploadResponse = g.toJson(
-                new UploadFileResponse(expectedUploadPath, expectedURL));
+            new UploadFileResponse(expectedUploadPath, expectedURL));
         String expectedHash = "newJobHash";
         String expectedCreateResponse = g.toJson(
-                new CreateJobResponse(expectedHash));
+            new CreateJobResponse(expectedHash));
         server.enqueue(new MockResponse().setBody(expectedUploadResponse));
         server.enqueue(new MockResponse().setBody(expectedCreateResponse));
         kioskJob.create(filePath);
@@ -118,26 +118,28 @@ public class KioskJobTest {
         // upload failure: valid but empty JSON
         server.enqueue(new MockResponse().setBody("{}"));
         assertThrows(IOException.class, () ->
-                kioskJob.create(filePath)
+            kioskJob.create(filePath)
         );
 
         // upload failure: local file does not exist throws error.
         String invalidFilePath = String.format(
-                "%s%s", folder.getRoot().getAbsolutePath(), "invalid.jpg");
+            "%s%s", folder.getRoot().getAbsolutePath(), "invalid.jpg");
         assertThrows(IOException.class, () ->
-                kioskJob.create(invalidFilePath)
+            kioskJob.create(invalidFilePath)
         );
 
         // upload failure: error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskJob.create(filePath)
+            kioskJob.create(filePath)
         );
 
         // upload failure: invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskJob.create(filePath)
+            kioskJob.create(filePath)
         );
 
         // create failure: valid but empty JSON
@@ -148,16 +150,18 @@ public class KioskJobTest {
 
         // create failure: error response
         server.enqueue(new MockResponse().setBody(expectedUploadResponse));
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskJob.create(filePath)
+            kioskJob.create(filePath)
         );
 
         // create failure: invalid JSON but successful response
         server.enqueue(new MockResponse().setBody(expectedUploadResponse));
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskJob.create(filePath)
+            kioskJob.create(filePath)
         );
     }
 
@@ -176,25 +180,27 @@ public class KioskJobTest {
         // 0 response throws error, hash not found.
         server.enqueue(new MockResponse().setBody("{\"value\": 0}"));
         assertThrows(IOException.class, () ->
-                kioskJob.expire(expireTime)
+            kioskJob.expire(expireTime)
         );
 
         // valid but empty JSON
         server.enqueue(new MockResponse().setBody("{}"));
         assertThrows(IOException.class, () ->
-                kioskJob.expire(expireTime)
+            kioskJob.expire(expireTime)
         );
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskJob.expire(expireTime)
+            kioskJob.expire(expireTime)
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskJob.expire(expireTime)
+            kioskJob.expire(expireTime)
         );
     }
 
@@ -213,15 +219,17 @@ public class KioskJobTest {
         assertEquals(null, kioskJob.getStatus());
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskJob.updateStatus()
+            kioskJob.updateStatus()
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskJob.updateStatus()
+            kioskJob.updateStatus()
         );
     }
 
@@ -230,7 +238,7 @@ public class KioskJobTest {
         // successful response
         String expectedValue = "success!";
         String expectedResponse = g.toJson(
-                new GetRedisValueResponse(expectedValue));
+            new GetRedisValueResponse(expectedValue));
 
         server.enqueue(new MockResponse().setBody(expectedResponse));
         String response = kioskJob.getOutputPath();
@@ -242,15 +250,17 @@ public class KioskJobTest {
         assertEquals(null, response);
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskJob.getOutputPath()
+            kioskJob.getOutputPath()
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskJob.getOutputPath()
+            kioskJob.getOutputPath()
         );
     }
 
@@ -259,7 +269,7 @@ public class KioskJobTest {
         // successful response
         String expectedValue = "success!";
         String expectedResponse = g.toJson(
-                new GetRedisValueResponse(expectedValue));
+            new GetRedisValueResponse(expectedValue));
         server.enqueue(new MockResponse().setBody(expectedResponse));
         String response = kioskJob.getErrorReason();
         assertEquals(expectedValue, response);
@@ -270,15 +280,17 @@ public class KioskJobTest {
         assertEquals(null, response);
 
         // error response
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        for (int i = 0; i < Constants.MAX_HTTP_RETRIES; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500).setBody("failed"));
+        }
         assertThrows(IOException.class, () ->
-                kioskJob.getErrorReason()
+            kioskJob.getErrorReason()
         );
 
         // invalid JSON but successful response
         server.enqueue(new MockResponse().setBody("failed"));
         assertThrows(JsonSyntaxException.class, () ->
-                kioskJob.getErrorReason()
+            kioskJob.getErrorReason()
         );
     }
 


### PR DESCRIPTION
`okhttp3` uses `Interceptors` to manage request retries, retries, and the like.

This PR introduces a new `RetryInterceptor` that will retry any failed request up to `MAX_HTTP_RETRIES` times. Several tests have been updated to enqueue more failure responses to ensure that the retries are exhausted.

Fixes #33 